### PR TITLE
Migrating to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk update && apk add curl \
   && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz \
     | zcat > /usr/local/bin/go-cron \
   && chmod u+x /usr/local/bin/go-cron \
-  && apk del curl \
   && rm -rf /var/cache/apk/* && \
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk update && apk add curl \
+RUN apk update && apk add curl bash \
   && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz \
     | zcat > /usr/local/bin/go-cron \
   && chmod u+x /usr/local/bin/go-cron \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add curl \
   && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz \
     | zcat > /usr/local/bin/go-cron \
   && chmod u+x /usr/local/bin/go-cron \
-  && rm -rf /var/cache/apk/* && \
+  && rm -rf /var/cache/apk/*
 
 EXPOSE 8080
 COPY go-cron.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk update && apk add curl bash \
-  && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz \
+  && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.7/go-cron-linux.gz \
     | zcat > /usr/local/bin/go-cron \
   && chmod u+x /usr/local/bin/go-cron \
   && rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM alpinelinux/base
+FROM alpine
 
 RUN apk update && apk add curl \
   && curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz \
     | zcat > /usr/local/bin/go-cron \
-  && chmod u+x /usr/local/bin/go-cron
+  && chmod u+x /usr/local/bin/go-cron \
+  && apk del curl \
+  && rm -rf /var/cache/apk/* && \
 
+EXPOSE 8080
 COPY go-cron.sh /usr/local/bin/
 CMD ["go-cron.sh"]
 

--- a/go-cron.sh
+++ b/go-cron.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec go-cron "$SCHEDULE" /bin/bash -c "$COMMAND"
+exec go-cron -s "$SCHEDULE" -p 8080 -- /bin/bash -c "$COMMAND"


### PR DESCRIPTION
This contains a number of tiny patches that will migrate to the latest versions of:
1. Alpine linux, since there is now an official image at docker
2. go-cron, since it is now at 0.0.7.

It also exposes port 8080 for health-checking, if necessary.
